### PR TITLE
fix setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 import os
-from setuptools import setup
+from setuptools import setup, find_packages
 
 VERSION = (1, 2)
 
@@ -26,7 +26,7 @@ setup(
     url='http://github.com/scottphilip/caller-lookup',
     author='Scott Philip',
     author_email='sp@scottphilip.com',
-    packages=['CallerLookup'],
+    packages=find_packages(),
     version=get_version_number(),
     install_requires=read('REQUIREMENTS.txt').splitlines(),
     test_suite='nose.collector',


### PR DESCRIPTION
Fix setup bug:

```python
----> 1 import CallerLookup

/private/tmp/ffx/venv/lib/python3.6/site-packages/CallerLookup/__init__.py in <module>()
      4 # Licence:      GNU GENERAL PUBLIC LICENSE (Version 3, 29 June 2007)
      5
----> 6 from CallerLookup.Main import lookup_number

/private/tmp/ffx/venv/lib/python3.6/site-packages/CallerLookup/Main.py in <module>()
      4 # Licence:      GNU GENERAL PUBLIC LICENSE (Version 3, 29 June 2007)
      5
----> 6 from CallerLookup.Responses import *
      7 from CallerLookup.Search import *
      8 from CallerLookup.Utils.Report import record

/private/tmp/ffx/venv/lib/python3.6/site-packages/CallerLookup/Responses.py in <module>()
      5
      6 from CallerLookup.Strings import CallerLookupLabel, CallerLookupKeys
----> 7 from CallerLookup.Utils.Logs import format_exception
      8
      9

ModuleNotFoundError: No module named 'CallerLookup.Utils'
```